### PR TITLE
Update go-github package and fix golint warning

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -18,7 +18,7 @@
 		},
 		{
 			"ImportPath": "github.com/google/go-github/github",
-			"Rev": "845773f8647cad81ce430e0b903e8818d356e317"
+			"Rev": "7ea4ee6d222607c11ea86e99a6f6723beeae785d"
 		},
 		{
 			"ImportPath": "github.com/google/go-querystring/query",

--- a/cli.go
+++ b/cli.go
@@ -249,7 +249,7 @@ func update() {
 		}
 
 		// download
-		tmpFileName, err := downloadFromUrl(*asset.BrowserDownloadUrl)
+		tmpFileName, err := downloadFromUrl(*asset.BrowserDownloadURL)
 		if err != nil {
 			logger.Errorln("Download error", err)
 			return


### PR DESCRIPTION
Second attempt at #7. It turns out that I had a _newer_ version of `github.com/go-github/github` in my `GOPATH`. I've updated it in Godeps. This also fixes a golint warning.