### PR TITLE
Replace semver.New with semver.Make

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -214,13 +214,13 @@ func update() {
 	logger.Infoln("Latest version is " + version)
 
 	// compare version
-	current, err := semver.New(VERSION[1:])
+	current, err := semver.Make(VERSION[1:])
 	if err != nil {
 		logger.Errorln("Semver parse error ", err)
 		return
 	}
 
-	latest, err := semver.New(version[1:])
+	latest, err := semver.Make(version[1:])
 	if err != nil {
 		logger.Errorln("Semver parse error ", err)
 		return


### PR DESCRIPTION
This patch fixes the following bug:
  $ go get github.com/git-hooks/git-hooks
  # github.com/git-hooks/git-hooks
  ../../go/src/github.com/git-hooks/git-hooks/cli.go:230: cannot use current (type *semver.Version) as type semver.Version in argument to latest.GT

I guess that's related to this commit:
  https://github.com/blang/semver/commit/2f3112b6f8f18f9df8743cc75ed51da08094ef6a