### PR TITLE
Autodetect protocol from git address

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -264,5 +264,22 @@ func TestIdentity(t *testing.T) {
 	})
 }
 
+func TestProtocol(t *testing.T) {
+	gitUrl := "https://my.git.repository.com/org/repo"
+	noProtocol, noProtocolNoUser := findProtocol(gitUrl)
+	assert.True(t, noProtocolNoUser == "my.git.repository.com/org/repo")
+	assert.True(t, noProtocol == "https://my.git.repository.com/org/repo")
+
+	gitUrl = "my.git.repository.com/org/repo"
+	noProtocol, noProtocolNoUser = findProtocol(gitUrl)
+	assert.True(t, noProtocolNoUser == "my.git.repository.com/org/repo")
+	assert.True(t, noProtocol == "https://my.git.repository.com/org/repo")
+
+	gitUrl = "ssh://git@my.git.repository.com:org/repo"
+	noProtocol, noProtocolNoUser = findProtocol(gitUrl)
+	assert.True(t, noProtocolNoUser == "my.git.repository.com/org/repo")
+	assert.True(t, noProtocol == "git@my.git.repository.com:org/repo")
+}
+
 func TestRun(t *testing.T) {
 }


### PR DESCRIPTION
This PR adds support for detecting the protocol from the `githooks.json`. Previously it was assuming all connections are going over https. Now they can go over ssh as well.
Example structure:

```
{
    "pre-commit": {
        "ssh://git@my.git.repo:org/repo": [
            "script1"
        ],
        "https://my.git.repo/org/repo": [
            "script1"
        ],
        "my.git.repo/org/repo": [
            "script1"
        ]
    }
}
```