### PR TITLE
Remove windows/386 and windows/amd64 from PLATFORMS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-PLATFORMS := darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm \
-	windows/386 windows/amd64 
+PLATFORMS := darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm 
 
 temp = $(subst /, ,$@)
 os = $(word 1, $(temp))


### PR DESCRIPTION
git-hooks does not support Windows now, so it makes no sense to build
for Windows.

We need to get #23 merged for using git-hooks on Windows.

(I have forgotten to remove these 😂)