### PR TITLE
hooks.global need not only be specified via system

### DIFF
--- a/dir.go
+++ b/dir.go
@@ -37,7 +37,7 @@ func hookDirs() map[string]string {
 	// global scope
 	// NOTE: git-hooks global hook actually configured via git --system
 	// configuration file
-	global, err := gitExec("config --get --system hooks.global")
+	global, err := gitExec("config --get hooks.global")
 	if err == nil {
 		path := global
 		isExist, _ := exists(path)
@@ -71,7 +71,7 @@ func hookConfigs() map[string]string {
 		}
 	}
 
-	global, err := gitExec("config --get --system hooks.globalconfig")
+	global, err := gitExec("config --get hooks.globalconfig")
 	if err == nil {
 		path := global
 		isExist, _ := exists(path)


### PR DESCRIPTION
The configuration is read from git, but like all other git configuration, should support being overridden by user and repo level configuration.

fixes #37 